### PR TITLE
Greybox tweaks

### DIFF
--- a/docs/greybox/login.html
+++ b/docs/greybox/login.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Artsy : Login</title>
-    <link rel="stylesheet" href="/docs/greybox/style.css">
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <div class="wrapper">

--- a/docs/greybox/main-alt.css
+++ b/docs/greybox/main-alt.css
@@ -24,7 +24,7 @@ nav {
     left: 0;
     right: 0;
     z-index: 10;
-    height: 48px;
+    height: 80px;
     width: 100%;
 }
 
@@ -61,27 +61,3 @@ ul {
     list-style-type: none;
     padding: 0;
 }
-
-.navi {
-    display: flex;
-    width: 100%;
-    justify-content: space-between;
-    align-items: center;
-
-}
-
-.logo {
-    padding-left: 20px;
-    text-transform: uppercase;
-    font-weight: bold;
-    font-size: larger;
-}
-
-.navlinks, li {
-    display: inline-flex;
-}
-
-.login {
-    padding-right: 20px;
-}
-

--- a/docs/greybox/main-alt.css
+++ b/docs/greybox/main-alt.css
@@ -24,7 +24,7 @@ nav {
     left: 0;
     right: 0;
     z-index: 10;
-    height: 80px;
+    height: 46px;
     width: 100%;
 }
 

--- a/docs/greybox/profile.css
+++ b/docs/greybox/profile.css
@@ -12,6 +12,7 @@
     margin: 0 10px;
     font-weight: bold;
     font-size: 1.4em;
+    color: red;
 }
 
 .box {

--- a/docs/greybox/profile.html
+++ b/docs/greybox/profile.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Artsy : Profile</title>
-    <link rel="stylesheet" href="main.css">
+    <link rel="stylesheet" href="main-alt.css">
     <link rel="stylesheet" href="profile.css">
 </head>
 <body>

--- a/docs/greybox/register.html
+++ b/docs/greybox/register.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Artsy : Register</title>
-    <link rel="stylesheet" href="/docs/greybox/style.css">
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <div class="wrapper">


### PR DESCRIPTION
Adjusted css link paths in html so they are not relative, because login + register html pages weren't displaying properly on github pages even though they worked fine locally.

Thought it best to create an alternate base css file `main-alt.css` for my greybox wireframes so I don't mess with anyone else html formatting